### PR TITLE
DBAAS-3187: replace sqlContext with Spark

### DIFF
--- a/Splice_Machine_Training/For Data Scientists/e. Using our Native Spark DataSource.ipynb
+++ b/Splice_Machine_Training/For Data Scientists/e. Using our Native Spark DataSource.ipynb
@@ -164,7 +164,7 @@
     "l = [(0,3.14,'Turing'), (1,4.14,'Newell'), (2,5.14,'Simon'), (3,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n"
    ]
   },
@@ -211,7 +211,7 @@
     "l = [(4,3.14,'Turing'), (5,4.14,'Newell'), (6,5.14,'Simon'), (7,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n",
     "df = splice.df(\"select * from DS.foo\")\n",
     "df.collect\n",

--- a/Splice_Machine_Training/For Data Scientists/f. Machine Learning with Spark MLlib.ipynb
+++ b/Splice_Machine_Training/For Data Scientists/f. Machine Learning with Spark MLlib.ipynb
@@ -837,7 +837,7 @@
     "\n",
     "transformed_df = lrModel.transform(df)\n",
     "transformed_df.createOrReplaceTempView(\"res_view\")\n",
-    "results = sqlContext.sql('SELECT prediction, probability, features from res_view')\n",
+    "results = spark.sql('SELECT prediction, probability, features from res_view')\n",
     "results.show(20)\n"
    ]
   },
@@ -976,7 +976,7 @@
     "df= test_data_with_uppercase_schema.toDF(*newNames)\n",
     "lrPredictions = lrModel.transform(df)\n",
     "lrPredictions.createOrReplaceTempView(\"pred_view\")\n",
-    "results = sqlContext.sql('SELECT prediction, probability, features FROM pred_view ORDER BY features')\n",
+    "results = spark.sql('SELECT prediction, probability, features FROM pred_view ORDER BY features')\n",
     "results.show(20)"
    ]
   },

--- a/Splice_Machine_Training/For Data Scientists/j. Exercises.ipynb
+++ b/Splice_Machine_Training/For Data Scientists/j. Exercises.ipynb
@@ -485,7 +485,7 @@
     "\n",
     "text_contents = str(z.input(\"SMS Message Contents\"))\n",
     "if len(text_contents) > 1:\n",
-    "    pred_df = sqlContext.createDataFrame([text_contents], StringType()).withColumnRenamed('value', 'SMS_CONTENT')\n",
+    "    pred_df = spark.createDataFrame([text_contents], StringType()).withColumnRenamed('value', 'SMS_CONTENT')\n",
     "    predPipe = generate_pipeline(predicting=True)\n",
     "\n",
     "    pred = predPipe.fit(df).transform(pred_df)\n",

--- a/Splice_Machine_Training/For Developers, Part II/f. Using our Native Spark DataSource.ipynb
+++ b/Splice_Machine_Training/For Developers, Part II/f. Using our Native Spark DataSource.ipynb
@@ -164,7 +164,7 @@
     "l = [(0,3.14,'Turing'), (1,4.14,'Newell'), (2,5.14,'Simon'), (3,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n"
    ]
   },
@@ -211,7 +211,7 @@
     "l = [(4,3.14,'Turing'), (5,4.14,'Newell'), (6,5.14,'Simon'), (7,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n",
     "df = splice.df(\"select * from DS.foo\")\n",
     "df.collect\n",

--- a/Splice_Machine_Training/For Developers, Part II/g. Machine Learning with Spark MLlib.ipynb
+++ b/Splice_Machine_Training/For Developers, Part II/g. Machine Learning with Spark MLlib.ipynb
@@ -837,7 +837,7 @@
     "\n",
     "transformed_df = lrModel.transform(df)\n",
     "transformed_df.createOrReplaceTempView(\"res_view\")\n",
-    "results = sqlContext.sql('SELECT prediction, probability, features from res_view')\n",
+    "results = spark.sql('SELECT prediction, probability, features from res_view')\n",
     "results.show(20)\n"
    ]
   },
@@ -976,7 +976,7 @@
     "df= test_data_with_uppercase_schema.toDF(*newNames)\n",
     "lrPredictions = lrModel.transform(df)\n",
     "lrPredictions.createOrReplaceTempView(\"pred_view\")\n",
-    "results = sqlContext.sql('SELECT prediction, probability, features FROM pred_view ORDER BY features')\n",
+    "results = spark.sql('SELECT prediction, probability, features FROM pred_view ORDER BY features')\n",
     "results.show(20)"
    ]
   },

--- a/cloud_notebooks/3. Splice Deep Dive/3.6 Using our Native Spark DataSource.ipynb
+++ b/cloud_notebooks/3. Splice Deep Dive/3.6 Using our Native Spark DataSource.ipynb
@@ -130,7 +130,7 @@
     "l = [(0,3.14,'Turing'), (1,4.14,'Newell'), (2,5.14,'Simon'), (3,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n"
    ]
   },
@@ -177,7 +177,7 @@
     "l = [(4,3.14,'Turing'), (5,4.14,'Newell'), (6,5.14,'Simon'), (7,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n",
     "df = splice.df(\"select * from DS.foo\")\n",
     "df.collect\n",

--- a/cloud_notebooks/3. Splice Deep Dive/3.6 Using our Spark Adapter.ipynb
+++ b/cloud_notebooks/3. Splice Deep Dive/3.6 Using our Spark Adapter.ipynb
@@ -128,7 +128,7 @@
     "l = [(0,3.14,'Turing'), (1,4.14,'Newell'), (2,5.14,'Simon'), (3,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n"
    ]
   },
@@ -175,7 +175,7 @@
     "l = [(4,3.14,'Turing'), (5,4.14,'Newell'), (6,5.14,'Simon'), (7,6.14,'Minsky')]\n",
     "rdd = sc.parallelize(l)\n",
     "rows = rdd.map(lambda x: Row(I=x[0], F=float(x[1]), V=str(x[2])))\n",
-    "schemaRows = sqlContext.createDataFrame(rows)\n",
+    "schemaRows = spark.createDataFrame(rows)\n",
     "splice.insert(schemaRows,'DS.foo')\n",
     "df = splice.df(\"select * from DS.foo\")\n",
     "df.collect\n",

--- a/cloud_notebooks/3. Splice Deep Dive/3.7 Python MLlib example.ipynb
+++ b/cloud_notebooks/3. Splice Deep Dive/3.7 Python MLlib example.ipynb
@@ -805,7 +805,7 @@
     "\n",
     "transformed_df = lrModel.transform(df)\n",
     "transformed_df.createOrReplaceTempView(\"res_view\")\n",
-    "results = sqlContext.sql('SELECT prediction, probability, features from res_view')\n",
+    "results = spark.sql('SELECT prediction, probability, features from res_view')\n",
     "results.show(20)\n"
    ]
   },
@@ -944,7 +944,7 @@
     "df= test_data_with_uppercase_schema.toDF(*newNames)\n",
     "lrPredictions = lrModel.transform(df)\n",
     "lrPredictions.createOrReplaceTempView(\"pred_view\")\n",
-    "results = sqlContext.sql('SELECT prediction, probability, features FROM pred_view ORDER BY features')\n",
+    "results = spark.sql('SELECT prediction, probability, features FROM pred_view ORDER BY features')\n",
     "results.show(20)"
    ]
   },

--- a/cloud_notebooks/3. Splice Deep Dive/3.8 Scala MLlib example.ipynb
+++ b/cloud_notebooks/3. Splice Deep Dive/3.8 Scala MLlib example.ipynb
@@ -540,7 +540,7 @@
     "from pyspark.ml.classification import LogisticRegression\n",
     "from pyspark.ml import Pipeline\n",
     "\n",
-    "splice = PySpliceContext(defaultJDBCURL, sqlContext)\n",
+    "splice = PySpliceContext(defaultJDBCURL, spark)\n",
     "```"
    ]
   },

--- a/cloud_notebooks/6. Internet of Things/6.4 Using Spark Streaming.ipynb
+++ b/cloud_notebooks/6. Internet of Things/6.4 Using Spark Streaming.ipynb
@@ -119,7 +119,7 @@
     "    }\n",
     "    \n",
     "\n",
-    "    val df_item = sqlContext.createDataFrame(rowRdd_item, schema_item)\n",
+    "    val df_item = spark.createDataFrame(rowRdd_item, schema_item)\n",
     "  \n",
     "    //If there are records, use Splice Adapter to insert the data to table\n",
     "    if(df_item.count > 0)\n",


### PR DESCRIPTION
sqlContext is just an attribute of the Spark object, so you can use spark instead of sqlContext for all of these calls.