### PR TITLE
Update 1.2 Create Notebook Users.ipynb

### DIFF
--- a/cloud_notebooks/1. Getting Started/1.2 Create Notebook Users.ipynb
+++ b/cloud_notebooks/1. Getting Started/1.2 Create Notebook Users.ipynb
@@ -59,7 +59,6 @@
    "source": [
     "%%sql\n",
     "grant access on schema mlmanager to USERNAME; \n",
-    "GRANT INSERT, SELECT on MLMANAGER.MODELS TO USERNAME;\n",
     "GRANT INSERT, SELECT on MLMANAGER.ARTIFACTS TO USERNAME;"
    ]
   }


### PR DESCRIPTION
The mlmanager.models table no longer exists, so we remove the need for insert/select. The models table and artifacts table have been merged so no new access is required.