### PR TITLE
DBAAS-4636: Surround exception in try / catch statement

### DIFF
--- a/cloud_notebooks/7. MLManager/7.2 Splice MLflow Support.ipynb
+++ b/cloud_notebooks/7. MLManager/7.2 Splice MLflow Support.ipynb
@@ -440,8 +440,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with mlflow.start_run(run_name='a run that failed'):\n",
-    "    raise Exception"
+    "try:\n",
+    "    with mlflow.start_run(run_name='a run that failed'):\n",
+    "        raise Exception\n",
+    "except:\n",
+    "    print('this run failed!')"
    ]
   },
   {


### PR DESCRIPTION
This notebook was failing the QA tests.  Added a try / catch around the expected failure. 