### PR TITLE
DBAAS-4188 : Spark3.0 updates, the changes will work with spark 2.4 also

### DIFF
--- a/cloud_notebooks/1. Data Science/2. Next Steps/Examples/MLManager AutoML with H2O.ipynb
+++ b/cloud_notebooks/1. Data Science/2. Next Steps/Examples/MLManager AutoML with H2O.ipynb
@@ -447,7 +447,7 @@
     "x.remove(y)\n",
     "\n",
     "# Create H2O Dataframe from Spark Dataframe\n",
-    "hdf = hc.as_h2o_frame(df)\n",
+    "hdf = hc.asH2OFrame(df)\n",
     "\n",
     "# Splice into train/test/validation\n",
     "train, test, valid = hdf.split_frame(ratios=RATIOS)\n",

--- a/cloud_notebooks/1. Data Science/2. Next Steps/Examples/MLManager NLP H2O Demo.ipynb
+++ b/cloud_notebooks/1. Data Science/2. Next Steps/Examples/MLManager NLP H2O Demo.ipynb
@@ -117,7 +117,7 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "# Spark Session\n",
-    "spark = SparkSession.builder.config('spark.driver.memoryOverhead',1000).config('spark.driver.memory','2g').getOrCreate()\n",
+    "spark = SparkSession.builder.config('spark.dynamicAllocation.enabled',"false").config('spark.driver.memoryOverhead',1000).config('spark.driver.memory','2g').getOrCreate()\n",
     "# Native Spark Data Source\n",
     "splice = PySpliceContext(spark)\n",
     "# Register Splice so we can access database functions\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Two changes were necessary for notebooks to work with Spark3.0. The changes are 
MLManager AutoML with H2O.ipynb : h2o.as_h2o_frame is replaced with h2o.asH2OFrame  . 
MLManager NLP H2O Demo.ipynb  : set dynamicAllocation to false.

## Motivation and Context
With spark3.0, H2o version is also changed, and the new version no longer supports as_h2o_frame. So had to change to asH2OFrame. The current H2o version does support asH2OFrame (other notebooks are using it). So this is safe to merge to master for the current release.

The other change is H2o does not support dynamicAllocation enabled. Since with spark3.0, it is enabled by default, so in the notebooks with H2o , its override to disable it.

## Dependencies
None

## How Has This Been Tested?
Run Notebooks and make sure they complete,
## Screenshots (if appropriate):
